### PR TITLE
feat: add CSV export for food inventory

### DIFF
--- a/app/api/foods/export/route.ts
+++ b/app/api/foods/export/route.ts
@@ -1,0 +1,111 @@
+import { desc, eq } from "drizzle-orm";
+import { headers } from "next/headers";
+import { type NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { foods } from "@/lib/db/schema";
+import { safeLogError } from "@/lib/utils";
+
+/**
+ * GET /api/foods/export - Export foods as CSV
+ *
+ * Query parameters:
+ * - archived: Filter by archived status ("true" | "false", optional - defaults to false)
+ *
+ * Returns a CSV file with all food inventory data
+ */
+export async function GET(request: NextRequest) {
+	const session = await auth.api.getSession({ headers: await headers() });
+	if (!session) {
+		return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+	}
+
+	try {
+		const { searchParams } = new URL(request.url);
+		const archivedParam = searchParams.get("archived");
+
+		let archivedFilter: boolean | null = null;
+		if (typeof archivedParam === "string") {
+			const normalized = archivedParam.trim().toLowerCase();
+			if (normalized === "true") {
+				archivedFilter = true;
+			} else if (normalized === "false") {
+				archivedFilter = false;
+			}
+		}
+
+		const query =
+			archivedFilter !== null
+				? db
+						.select()
+						.from(foods)
+						.where(eq(foods.archived, archivedFilter))
+						.orderBy(desc(foods.createdAt))
+				: db.select().from(foods).orderBy(desc(foods.createdAt));
+
+		const allFoods = await query;
+
+		const csvHeaders = [
+			"Name",
+			"Preference",
+			"Inventory Quantity",
+			"Archived",
+			"Notes",
+			"Phosphorus (DMB %)",
+			"Protein (DMB %)",
+			"Fat (DMB %)",
+			"Fiber (DMB %)",
+			"Created At",
+		];
+
+		const escapeCSVField = (value: string | number | boolean | null): string => {
+			if (value === null || value === undefined) {
+				return "";
+			}
+			const stringValue = String(value);
+			if (
+				stringValue.includes(",") ||
+				stringValue.includes('"') ||
+				stringValue.includes("\n") ||
+				stringValue.includes("\r")
+			) {
+				return `"${stringValue.replace(/"/g, '""')}"`;
+			}
+			return stringValue;
+		};
+
+		const csvRows = allFoods.map((food) =>
+			[
+				escapeCSVField(food.name),
+				escapeCSVField(food.preference),
+				escapeCSVField(food.inventoryQuantity),
+				escapeCSVField(food.archived ? "Yes" : "No"),
+				escapeCSVField(food.notes),
+				escapeCSVField(food.phosphorusDmb),
+				escapeCSVField(food.proteinDmb),
+				escapeCSVField(food.fatDmb),
+				escapeCSVField(food.fiberDmb),
+				escapeCSVField(food.createdAt),
+			].join(","),
+		);
+
+		const csvContent = [csvHeaders.join(","), ...csvRows].join("\n");
+
+		const timestamp = new Date().toISOString().split("T")[0];
+		const filename = `cat-food-inventory-${timestamp}.csv`;
+
+		return new NextResponse(csvContent, {
+			status: 200,
+			headers: {
+				"Content-Type": "text/csv; charset=utf-8",
+				"Content-Disposition": `attachment; filename="${filename}"`,
+			},
+		});
+	} catch (error) {
+		safeLogError("GET /api/foods/export", error);
+		return NextResponse.json(
+			{ error: "Failed to export foods" },
+			{ status: 500 },
+		);
+	}
+}

--- a/components/foods/food-filters.tsx
+++ b/components/foods/food-filters.tsx
@@ -5,6 +5,7 @@ import {
 	ArrowUpAZ,
 	ChevronDown,
 	ChevronUp,
+	Download,
 	HelpCircle,
 	Minus,
 	RotateCcw,
@@ -36,6 +37,8 @@ type FoodFiltersProps = {
 	sortOrder: "asc" | "desc";
 	onSortOrderToggle: () => void;
 	onReset: () => void;
+	onExport: () => void;
+	isExporting?: boolean;
 	isMinimized: boolean;
 	onToggleMinimize: () => void;
 };
@@ -52,6 +55,8 @@ export function FoodFilters({
 	sortOrder,
 	onSortOrderToggle,
 	onReset,
+	onExport,
+	isExporting,
 	isMinimized,
 	onToggleMinimize,
 }: FoodFiltersProps) {
@@ -79,6 +84,17 @@ export function FoodFilters({
 				>
 					<RotateCcw className="size-4" />
 					<span className="">Reset</span>
+				</Button>
+				<Button
+					variant="outline"
+					size="default"
+					onClick={onExport}
+					disabled={isExporting}
+					title="Export to CSV"
+					className="shadow-none"
+				>
+					<Download className="size-4" />
+					<span className="">{isExporting ? "Exporting..." : "Export"}</span>
 				</Button>
 				<Button
 					variant="outline"

--- a/components/foods/foods-page-client.tsx
+++ b/components/foods/foods-page-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
 import { FoodFilters } from "@/components/foods/food-filters";
 import { FoodList } from "@/components/foods/food-list";
 import { QuickAddDialog } from "@/components/layout/quick-add-dialog";
@@ -56,6 +57,7 @@ export function FoodsPageClient() {
 	const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
 	const [isFiltersMinimized, setIsFiltersMinimized] = useState(false);
 	const [foodToDelete, setFoodToDelete] = useState<Food | null>(null);
+	const [isExporting, setIsExporting] = useState(false);
 	const handleAddFood = async (food: FoodInput) => {
 		const success = await addFood(food);
 		if (success) {
@@ -82,6 +84,32 @@ export function FoodsPageClient() {
 
 	const confirmDeleteFood = (food: Food) => {
 		setFoodToDelete(food);
+	};
+
+	const handleExport = async () => {
+		setIsExporting(true);
+		try {
+			const response = await fetch("/api/foods/export?archived=false");
+			if (!response.ok) {
+				throw new Error("Failed to export");
+			}
+			const blob = await response.blob();
+			const url = window.URL.createObjectURL(blob);
+			const a = document.createElement("a");
+			a.href = url;
+			const contentDisposition = response.headers.get("Content-Disposition");
+			const filenameMatch = contentDisposition?.match(/filename="(.+)"/);
+			a.download = filenameMatch?.[1] ?? "cat-food-inventory.csv";
+			document.body.appendChild(a);
+			a.click();
+			window.URL.revokeObjectURL(url);
+			document.body.removeChild(a);
+			toast.success("Inventory exported successfully");
+		} catch {
+			toast.error("Failed to export inventory");
+		} finally {
+			setIsExporting(false);
+		}
 	};
 
 	const filteredAndSortedFoods = useMemo(() => {
@@ -189,6 +217,8 @@ export function FoodsPageClient() {
 						setSortOrder(sortOrder === "asc" ? "desc" : "asc")
 					}
 					onReset={resetFilters}
+					onExport={handleExport}
+					isExporting={isExporting}
 					isMinimized={isFiltersMinimized}
 					onToggleMinimize={() => setIsFiltersMinimized(!isFiltersMinimized)}
 				/>


### PR DESCRIPTION
Add ability to export food inventory data as a CSV file:
- New API endpoint at /api/foods/export that generates CSV
- Export button in food filters toolbar
- Includes all food data: name, preference, inventory, notes, nutrition info
- Properly escapes CSV fields with special characters